### PR TITLE
Make the API consistent with Statistics.jl/StatsBase.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,13 @@ HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.25"
 HypothesisTests = "0.10"
 SpecialFunctions = "1,2"
+StatsBase = "0.33,0.34"
 julia = "1.7"
 
 [extras]

--- a/src/CircStats.jl
+++ b/src/CircStats.jl
@@ -1,6 +1,6 @@
 module CircStats
 
-using Statistics,LinearAlgebra,Distributions,SpecialFunctions,HypothesisTests
+using Statistics,LinearAlgebra,Distributions,SpecialFunctions,HypothesisTests,StatsBase
 
 include("src.jl")
 

--- a/src/src.jl
+++ b/src/src.jl
@@ -17,19 +17,29 @@ Computes mean resultant vector length for circular data.
 
 	return: mean resultant length
 """
-function circ_r(α; w = ones(size(α)), d = 0, dims = 1)
-  # compute weighted sum of cos and sin of angles
-  r = sum(w .* cis.(α); dims)
+function circ_r end
+function circ_r(α; d = 0, dims=Colon())
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, dims)
 
   # obtain length
-  r = abs.(r) ./ sum(w; dims)
+  r = abs.(cs_mean)
 
   # for data with known spacing, apply correction factor to correct for bias in the estimation of r (see Zar, p. 601, equ. 26.16)
-  if d != 0
-    c = d / 2 / sin(d / 2)
-    r *= c
-  end
-  length(r) == 1 ? r[1] : r
+  c = _usinc(d / 2)
+  return r / c
+end
+function circ_r(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int=1; d = 0)
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, w, dim)
+
+  # obtain length
+  r = abs.(cs_mean)
+
+  # for data with known spacing, apply correction factor to correct for bias in the estimation of r (see Zar, p. 601, equ. 26.16)
+  c = _usinc(d / 2)
+  return r / c
+end
 end
 
 """

--- a/src/src.jl
+++ b/src/src.jl
@@ -493,10 +493,18 @@ Computes Rayleigh test for non-uniformity of circular data.
 	- p: p-value of Rayleigh's test
 	- z: value of the z-statistic
 """
-function circ_rtest(α; w = ones(size(α)), d = 0)
-  r = circ_r(α; w, d)
+function circ_rtest end
+function circ_rtest(α; dims=Colon(), d = 0, r = circ_r(α; dims=dims, d=d))
+  n = prod(size(α)[dims])
+  return _circ_rtest(r, n)
+end
+function circ_rtest(α::AbstractArray, w::StatsBase.FrequencyWeights, dim::Int=1; d = 0, r = circ_r(α, w, dim; d=d))
+  all(isinteger, w) || throw(ArgumentError("weights must be integer counts"))
   n = sum(w)
+  return _circ_rtest(r, n)
+end
 
+function _circ_rtest(r, n)
   # compute Rayleigh's R (equ. 27.1)
   R = n * r
 

--- a/src/src.jl
+++ b/src/src.jl
@@ -452,19 +452,25 @@ Computes descriptive statistics for circular data.
 
   return: descriptive statistics
 """
-function circ_stats(α::AbstractVector; w = ones(size(α)), d = 0)
+function circ_stats end
+function circ_stats(
+  α::AbstractVector,
+  w::StatsBase.AbstractWeights=StatsBase.uweights(length(α));
+  d = 0,
+)
   # mean
-  mean = circ_mean(α; w).μ
+  mean, r = circ_mean_and_r(α, w; d=d)
   # median
   median = circ_median(α)
   # variance
-  var = circ_var(α; w, d)
+  var = (circ_var(α, w; r=r, kind=:circular), circ_var(α, w; r=r, kind=:angular))
   # standard deviation
-  std, std0 = circ_std(α; w, d)
+  std = circ_std(α, w; r=r, kind=:angular)
+  std0 = circ_std(α, w; r=r, kind=:circular)
   # skewness
-  skewness, skewness0 = circ_skewness(α; w)
+  skewness, skewness0 = circ_skewness(α, w; mean=mean, r=r)
   # kurtosis
-  kurtosis, kurtosis0 = circ_kurtosis(α; w)
+  kurtosis, kurtosis0 = circ_kurtosis(α, w; mean=mean, r=r)
 
   return (; mean, median, var,std,std0, skewness,skewness0,kurtosis,kurtosis0)
 end

--- a/src/src.jl
+++ b/src/src.jl
@@ -40,6 +40,39 @@ function circ_r(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int=1; d =
   c = _usinc(d / 2)
   return r / c
 end
+
+"""
+  circ_mean_and_r(α; d = 0, dims=Colon())
+  circ_mean_and_r(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int=1; d = 0)
+
+Computes the mean direction and mean resultant length for circular data.
+"""
+function circ_mean_and_r end
+function circ_mean_and_r(α; d = 0, dims=Colon())
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, dims)
+
+  μ = angle.(cs_mean)
+
+  # obtain length
+  r = abs.(cs_mean)
+
+  # for data with known spacing, apply correction factor to correct for bias in the estimation of r (see Zar, p. 601, equ. 26.16)
+  c = _usinc(d / 2)
+  return μ, r / c
+end
+function circ_mean_and_r(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int=1; d = 0)
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, w, dim)
+
+  μ = angle.(cs_mean)
+
+  # obtain length
+  r = abs.(cs_mean)
+
+  # for data with known spacing, apply correction factor to correct for bias in the estimation of r (see Zar, p. 601, equ. 26.16)
+  c = _usinc(d / 2)
+  return μ, r / c
 end
 
 """

--- a/src/src.jl
+++ b/src/src.jl
@@ -1,3 +1,12 @@
+_usinc(x::Real) = iszero(x) ? one(x) : (isinf(x) ? zero(x) : sin(x) / x)
+
+_complex_mean(α, dims) = mean(cis, α, dims=dims)
+_complex_mean(α, dims::Colon) = mean(cis, α)
+function _complex_mean(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int)
+    return mean(cis.(α), w, dim)
+end
+_complex_mean(α::AbstractArray, w::StatsBase.UnitWeights, dim::Int) = _complex_mean(α, dim)
+
 """
 Computes mean resultant vector length for circular data.
 

--- a/src/src.jl
+++ b/src/src.jl
@@ -84,23 +84,23 @@ Computes the mean direction for circular data.
 
 	return:
 	- μ: mean direction
-	- ul: upper 95% confidence limit
-	- ll: lower 95% confidence limit
 """
-function circ_mean(α; w = ones(size(α)), dims = 1)
-  # compute weighted sum of cos and sin of angles
-  r = sum(w .* cis.(α); dims)
+function circ_mean end
+function circ_mean(α; dims=Colon())
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, dims)
 
-  # obtain mean by
-  μ = angle.(r)
-  μ = length(μ) == 1 ? μ[1] : μ
+  μ = angle.(cs_mean)
 
-  # confidence limits
-  t = circ_confmean(α; xi = 0.05, w, d = 0, dims)
-  ul = μ .+ t
-  ll = μ .- t
+  return μ
+end
+function circ_mean(α::AbstractArray, w::StatsBase.AbstractWeights, dim::Int=1)
+  # compute weighted mean of cos and sin of angles
+  cs_mean = _complex_mean(α, w, dim)
 
-  return (; μ, ul, ll)
+  μ = angle.(cs_mean)
+
+  return μ
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,7 +72,7 @@ using Test, CircStats
     mp, ρp, μp = circ_moment(av;cent=true)
     @test mp ≈ 0.481125184946105 - 0.000000000000000im
     @test ρp ≈ 0.481125184946105
-    @test μp ≈ 3.741981750042832e-17
+    @test μp ≈ 3.741981750042832e-17 atol=1e-16
 
     mp, ρp, μp = circ_moment(am)
     mp, ρp, μp = circ_moment(am;cent=true)


### PR DESCRIPTION
This PR makes a number of breaking changes to make the API of `circ_foo` more consistent with its corresponding function `foo` (if defined) in Statistics/StatsBase.

## Main changes

### Supporting `StatsBase.AbstractWeights`

Weighted scalar statistics are handled in StatsBase using `StatsBase.AbstractWeights` types, which can represent not only frequency weights but also other kinds of weights. Unlike the current API, weights in StatsBase are always vectors, so when they are used, the `dims` keyword is not supported, and instead an optional positional argument `dim::Int` is provided, specifying the single dimension that will be reduced to a singleton. i.e., the signatures are

```julia
foo(x::Any; dims=Colon(), kwargs...)  # reduce over specified dimensions of `x`, defaulting to flattening
foo(x::AbstractArray, w::AbstractWeights, dim::Int=1, kwargs...)  # weighted reduction over `dim`
```

This PR adopts the same signatures for `circ_foo`, which unfortunately does require some code duplication. Future refactors could reduce this code duplication.

### Avoiding recomputing `circ_mean` and `circ_r`

When a function requires `r` or `mean`, it now accepts one or both of these as a keyword argument, allowing for some speed-ups. See how `circ_stats` does this for example. It also adds `circ_mean_and_r`, analogous to `mean_and_var` and `mean_and_std` in StatsBase.

### Return a single statistic

Now `circ_mean` returns just the mean, while `circ_std` and `circ_var` accept a `kind` keyword to specify the kind of statistic to return. It would be nice if we could do something similar for `circ_skewness` or `circ_kurtosis` as well. `circ_moment` could be similarly simplified to return the complex moment, but as this isn't consistent with the other moment functions, this doesn't seem ideal.

## What's left

- [ ] implement API changes for scalar statistics
- [ ] implement API changes for statistical tests
- [ ] implement any additional API changes to `circ_skewness`, `circ_kurtosis`, and `circ_moment`
- [ ] update tests to use `AbstractWeights` weight types.

## Discussion

Before this PR, this package supported multidimensional arrays of weights. Is there a clear use case for this? https://github.com/JuliaStats/StatsBase.jl/issues/776 discusses adding something similar to StatsBase, but if this happens, it wouldn't happen for some time.

cc  @huangziwei, @meteore